### PR TITLE
Fix: Production cleanup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,5 @@
+NODE_ENV=production
+
 PORT=8000
 
 MAX_IMG_SIZE=2000000

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ View [Note](#notes) section for more info.
 $ npx prisma generate
 ```
 
-## Running the app
+## Running the server for development
 
 ```bash
 # development watch mode
@@ -31,6 +31,24 @@ $ npm run docker:start
 
 # stop docker mode
 $ npm run docker:stop
+```
+
+## Building the server for production
+
+- Remember to set `NODE_ENV` to `production`
+
+- Remember to set `DATABASE_URL` to your desired Postgres database
+
+```bash
+# Build the server
+npm run build
+
+# Run the server file using npm script
+npm run start:prod
+
+# or with Node.js
+
+node dist/src/main
 ```
 
 ## Test

--- a/nest-cli.json
+++ b/nest-cli.json
@@ -1,8 +1,11 @@
 {
   "$schema": "https://json.schemastore.org/nest-cli",
   "collection": "@nestjs/schematics",
-  "sourceRoot": "src",
+  "sourceRoot": ".",
+  "entryFile": "/src/main",
   "compilerOptions": {
-    "deleteOutDir": true
+    "deleteOutDir": true,
+    "assets": [".env", "prisma/*"],
+    "watchAssets": true
   }
 }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "start": "nest start",
     "start:dev": "nest start --watch",
     "start:debug": "nest start --debug --watch",
-    "start:prod": "node dist/main",
+    "start:prod": "node dist/src/main",
     "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",
     "test": "jest",
     "test:watch": "jest --watch",

--- a/src/dev/dev.controller.ts
+++ b/src/dev/dev.controller.ts
@@ -1,9 +1,8 @@
-import { Body, Controller, Get, Post, UseGuards } from "@nestjs/common";
+import { Body, Controller, Post, UseGuards } from "@nestjs/common";
 import { DevService } from "./dev.service";
 import { GetSiweMessageDTO, GetSiweMessageResponse } from "./dev.type";
 import { NonEmptyBodyGuard, NonProductionGuard } from "./dev.guard";
 import { SkipThrottle } from "@nestjs/throttler";
-import { AddressThrottleGuard } from "@/auth/guards/address.guard";
 import { SignInWithCredentialsDTO } from "@/auth/types/SignInWithCredentials";
 import { EmptyResponse } from "@/utils/types/EmptyResponse";
 
@@ -13,7 +12,7 @@ import { EmptyResponse } from "@/utils/types/EmptyResponse";
 export class DevController {
   constructor(private readonly devService: DevService) {}
 
-  @Post("/siwe-message")
+  @Post("siwe-message")
   @UseGuards(NonEmptyBodyGuard)
   requestSiweMessage(@Body() input: GetSiweMessageDTO): GetSiweMessageResponse {
     const message = this.devService.getSiweMessage(input);
@@ -22,13 +21,7 @@ export class DevController {
     };
   }
 
-  @Get("rate-limit-test")
-  @UseGuards(AddressThrottleGuard)
-  testRateLimit() {
-    return { message: "Hello, World" };
-  }
-
-  @Post("/sign-up-admin")
+  @Post("sign-up-admin")
   @UseGuards(NonEmptyBodyGuard)
   async requestAdminAccount(
     @Body() credientials: SignInWithCredentialsDTO,

--- a/src/dev/dev.guard.ts
+++ b/src/dev/dev.guard.ts
@@ -2,12 +2,15 @@ import {
   CanActivate,
   ExecutionContext,
   ForbiddenException,
+  Logger,
 } from "@nestjs/common";
 
 /**
  * Only allow in non-production
  */
 export class NonProductionGuard implements CanActivate {
+  private readonly logger = new Logger(NonProductionGuard.name);
+
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   canActivate(context: ExecutionContext): boolean {
     const environment = process.env.NODE_ENV;
@@ -17,6 +20,7 @@ export class NonProductionGuard implements CanActivate {
     }
 
     if (environment.toLowerCase() == "production") {
+      this.logger.error("Cannot access dev endpoints on production");
       return false;
     }
 
@@ -25,6 +29,8 @@ export class NonProductionGuard implements CanActivate {
 }
 
 export class NonEmptyBodyGuard implements CanActivate {
+  private readonly logger = new Logger(NonEmptyBodyGuard.name);
+
   canActivate(context: ExecutionContext): boolean {
     const request = context.switchToHttp().getRequest<Request>();
     if (
@@ -32,6 +38,7 @@ export class NonEmptyBodyGuard implements CanActivate {
       (request.body.constructor === Object &&
         Object.keys(request.body).length === 0)
     ) {
+      this.logger.error("Does not accept empty body request");
       throw new ForbiddenException("Does not accept empty body request");
     }
 


### PR DESCRIPTION
- Adjust NestJS config to build final production files
- Disable `/dev` endpoints to avoid exposing important APIs

- Update docs about the build and deploy process